### PR TITLE
Remove by id and not by object

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,10 +61,10 @@ module.exports = function(dir) {
     
     // delete an object's file
     
-    remove: function(obj, cb) {
+    remove: function(id, cb) {
       var action = function(err) {
         if (err) return cb(err);
-        fs.unlink(path.join(dir, obj.id + '.json'), function(err) {
+        fs.unlink(path.join(dir, id + '.json'), function(err) {
           cb(err);
         });
       }

--- a/readme.md
+++ b/readme.md
@@ -68,11 +68,11 @@ store.list(function(err, objects) {
 
 ### Removing stored objects
 
-A stored object may be removed simply by passing the object to the `remove()` function.
-The object's `id` attribute will be used to remove the object's file from the file system.
+A stored object may be removed simply by passing the object's `id` attribute to the `remove()` function.
+The attribute will be used to remove the object's file from the file system.
 
 ```javascript
-store.remove(donkey, function(err) {
+store.remove('12345', function(err) {
   // called after the file has been removed
   if (err) throw err; // err if the file removal failed
 });

--- a/spec/store_spec.js
+++ b/spec/store_spec.js
@@ -81,7 +81,7 @@ describe("Store", function() {
     store.add(obj, function(err) {
       assert.ok(!err, 'error on save: ' + err);
       assert.isTrue(fs.existsSync(file), 'create file');
-      store.remove(obj, function(err) {
+      store.remove(obj.id, function(err) {
         assert.ok(!err, 'error on remove: ' + err);
         assert.isFalse(fs.existsSync(file), 'remove file');
         done();


### PR DESCRIPTION
We should remove objects by `id` and not by the objects itself – the same as we do with `load`.