### PR TITLE
Update nodeUUID dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "async": "^1.4.2",
     "graceful-fs": "^4.1.2",
     "mkdirp": "^0.5.1",
-    "node-uuid": "^1.4.3"
+    "node-uuid": "^1.4.4"
   },
   "devDependencies": {
     "temp": "^0.8.3",


### PR DESCRIPTION
Update nodeUUID dependency to "^1.4.4". This is to remedy the "Insecure Entropy Source" vulnerability found in earlier versions.
See also https://nodesecurity.io/advisories/uuid_insecure-entropy-source-mathrandom