### PR TITLE
Update doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ npm install json-fs-store
 The store module is a function that takes a single parameter: the path to the location on the file system where you want to store your objects. 
 
 ```javascript
-var store = require('json-fs-store')('/path/to/storage/location');
+var store = require('json-fs-store')('./path/to/storage/location');
 ```
 
 If you omit the storage location the 'store' directory in your current working directory will be used.


### PR DESCRIPTION
Passing `/path/to/storage/location` will throw an error because it will try to create the folder in the root of your filesystem, which isn't allowed:

`Error: EACCES: permission denied, mkdir`

The relative path will work: `./path/to/storage/location`.

It got me the first time I've tried this module so that's why this PR.

Hope it helps.
Thanks for this module by the way!